### PR TITLE
Bump bugclerk to 1.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.jboss.jbossset</groupId>
       <artifactId>bugclerk-dist</artifactId>
-      <version>1.0.6.Final</version>
+      <version>1.0.7.Final</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This is blocked by https://github.com/jboss-set/bug-clerk/pull/121 and a new 1.0.7.Final release